### PR TITLE
Use prange and array views in pure cython example

### DIFF
--- a/list_cy.pyx
+++ b/list_cy.pyx
@@ -1,24 +1,29 @@
 # cython: language_level=3
-# from cython.parallel import prange
+from cython.parallel cimport prange
+from cython.view cimport array as cvarray
+cimport openmp, cython
 
+cdef float sum_list(double[:] a_list) nogil:
+    cdef double internal_count = 0
+    for j in range(a_list.shape[0]):
+        with cython.boundscheck(False):
+            internal_count += a_list[j]
+    return internal_count
 
-cpdef float iterate_list(a_list):
-
+cpdef float iterate_list(double[:,:] a_list):
     cdef double count = 0
     cdef int i, j
-    for i in range(len(a_list)):
-        internal_list = a_list[i]
-        for j in range(len(internal_list)):
-            count += internal_list[j]
+    for i in prange(a_list.shape[0], nogil=True):
+        count += sum_list(a_list[i, :])
     print(count)
     return count
 
 
-cpdef list make_list(a_list):
+cpdef double[:,:] make_list(a_list):
     cdef int i, j
-    for i in range(10**4):
-        new_list = []
-        for j in range(10**4):
-            new_list.append(0.01)
-        a_list.append(new_list)
-    return a_list
+    cdef double[:,:] my_list = cvarray(shape=(10**4, 10**4), itemsize=sizeof(double), format="d")
+    for i in prange(my_list.shape[0], nogil=True):
+        for j in range(my_list.shape[1]):
+            with cython.boundscheck(False):
+                my_list[i, j] = 0.01
+    return my_list

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-from setuptools import setup
+from setuptools import setup, Extension
 from setuptools_rust import Binding, RustExtension
 
 setup(
@@ -8,10 +8,18 @@ setup(
     zip_safe=False,
 )
 
+setup(name="list_cy",
+      ext_modules=[
+        Extension('list_cy',
+                  sources=['list_cy.pyx'],
+                  extra_compile_args=['-O3', '-fopenmp'],
+                  extra_link_args=['-fopenmp'])
+      ]
+)
 
 from Cython.Build import Cythonize
 Cythonize.main(["*[!list_numba|main|simple_list]*.py", "-3", "--inplace"])
-Cythonize.main(["*.pyx", "-3", "--inplace"])
+#Cythonize.main(["*.pyx", "-3", "--inplace"])
 # for path in paths:
 #     Cythonize.main([path, "-3", "--inplace"])
 


### PR DESCRIPTION
The performance comparison against Cython isn't quite fair as-is.  It's fully possible to for cython to release the GIL for the internal loops.