### PR TITLE
Make list_cy more idiomatic

### DIFF
--- a/list_cy.pyx
+++ b/list_cy.pyx
@@ -2,23 +2,17 @@
 # from cython.parallel import prange
 
 
-cpdef float iterate_list(a_list):
-
-    cdef double count = 0
-    cdef int i, j
-    for i in range(len(a_list)):
-        internal_list = a_list[i]
-        for j in range(len(internal_list)):
-            count += internal_list[j]
+cpdef float iterate_list(list a_list):
+    cdef double count = 0, d
+    cdef int i
+    cdef list internal_list
+    for internal_list in a_list:
+        for d in internal_list:
+            count += d
     print(count)
     return count
 
 
 cpdef list make_list(a_list):
     cdef int i, j
-    for i in range(10**4):
-        new_list = []
-        for j in range(10**4):
-            new_list.append(0.01)
-        a_list.append(new_list)
-    return a_list
+    return [[0.01]*(10**4) for _ in range(10**4)]


### PR DESCRIPTION
This is a more idiomatic implementation of cy_list, which avoids several performance pitfalls.  On my machine, this results in about a 2x improvement in performance.  This PR is incompatible with #2; maybe they should be separate tests.

