### PR TITLE
Rust - Numpy 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14,6 +14,12 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "cfg-if"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -24,7 +30,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
 ]
 
@@ -34,7 +40,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94af6efb46fef72616855b036a624cf27ba656ffc9be1b9a3c931cfc7749a9a9"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -45,7 +51,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2584f639eb95fea8c798496315b297cf81b9b58b6d30ab066a75455333cf4b12"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -59,7 +65,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7e9d99fa91428effe99c5c6d4634cdeba32b8cf784fc428a2a687f61a952c49"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -77,8 +83,9 @@ dependencies = [
 name = "cython_test"
 version = "0.1.0"
 dependencies = [
+ "ndarray",
+ "numpy",
  "pyo3",
- "rayon",
 ]
 
 [[package]]
@@ -136,7 +143,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61124eeebbd69b8190558df225adf7e4caafce0d743919e5d6b19652314ec5ec"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -183,10 +190,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "matrixmultiply"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "916806ba0031cd542105d916a97c8572e1fa6dd79c9c51e7eb43a09ec2dd84c1"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
 name = "memoffset"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f83fb6581e8ed1f85fd45c116db8405483899489e38406156c25eb743554361d"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c0d5c9540a691d153064dc47a4db2504587a75eae07bf1d73f7a596ebc73c04"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "rawpointer",
+ "rayon",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "747d632c0c558b87dbabbe6a82f3b4ae03720d0646ac5b7b4dae89394be5f2c5"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+dependencies = [
+ "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
 dependencies = [
  "autocfg",
 ]
@@ -199,6 +257,20 @@ checksum = "05499f3756671c15885fee9034446956fff3f243d6077b91e5767df161f766b3"
 dependencies = [
  "hermit-abi",
  "libc",
+]
+
+[[package]]
+name = "numpy"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7073fae1e0b82409533a29c6f804b79783d7b2d3c07728fdc4d884eda8cd4f0"
+dependencies = [
+ "cfg-if 0.1.10",
+ "libc",
+ "ndarray",
+ "num-complex",
+ "num-traits",
+ "pyo3",
 ]
 
 [[package]]
@@ -218,7 +290,7 @@ version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7a782938e745763fe6907fc6ba86946d72f49fe7e21de074e08128a99fb018"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "instant",
  "libc",
  "redox_syscall",
@@ -266,7 +338,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4837b8e8e18a102c23f79d1e9a110b597ea3b684c95e874eb1ad88f8683109c3"
 dependencies = [
- "cfg-if",
+ "cfg-if 1.0.0",
  "ctor",
  "indoc",
  "inventory",
@@ -307,6 +379,12 @@ checksum = "c3d0b9745dc2debf507c8422de05d7226cc1f0644216dfdfead988f9b1ab32a7"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,9 @@ path = "src/list_rust.rs"
 crate-type = ["cdylib"]
 
 [dependencies]
-rayon = "1.5.0" 
+numpy = "0.13"
+ndarray = {version = "0.14", features = ["rayon"]}
+
 
 [dependencies.pyo3]
 version = "0.13.2"

--- a/main.py
+++ b/main.py
@@ -17,6 +17,7 @@ import list_py_c
 import simple_list
 import list_cy
 import list_rust
+import numpy as np
 # import list_numba
 
 list_julia.eval('include("list_julia.jl")')
@@ -36,11 +37,17 @@ _a_list: List[List[float]]
 # list_numba.iterate_list(_nb_a_list)
 # print("Numba multi-threading needed time: " + str(time.time() - ttt))
 
-a_list = []  # type: ignore
 ttt = time.time()
-a_list = list_rust.make_list(a_list)
-list_rust.iterate_list(a_list)
-print("Rust multithreading before needed time: " + str(time.time() - ttt))
+a_list = np.empty((10**4, 10**4))
+a_list = list_rust.make_list_py(a_list)
+list_rust.iterate_list_py(a_list)
+print("Rust time: " + str(time.time() - ttt))
+
+ttt = time.time()
+a_list = np.empty((10**4, 10**4))
+a_list = list_rust.make_list_py(a_list)
+list_rust.iterate_list_multi_py(a_list)
+print("Rust with multithreading time: " + str(time.time() - ttt))
 
 a_list = []  # type: ignore
 ttt = time.time()
@@ -53,12 +60,6 @@ ttt = time.time()
 a_list = list_julia.make_list(a_list)
 list_julia.Threaded.iterate_list(a_list)
 print("Julia multi-threading needed time: " + str(time.time() - ttt))
-
-a_list = []  # type: ignore
-ttt = time.time()
-a_list = list_rust.make_list(a_list)
-list_rust.iterate_list(a_list)
-print("Rust multithreading after needed time: " + str(time.time() - ttt))
 
 a_list = []  # type: ignore
 ttt = time.time()

--- a/main.py
+++ b/main.py
@@ -41,13 +41,19 @@ ttt = time.time()
 a_list = np.empty((10**4, 10**4))
 a_list = list_rust.make_list_py(a_list)
 list_rust.iterate_list_py(a_list)
-print("Rust time: " + str(time.time() - ttt))
+print("Rust-numpy time: " + str(time.time() - ttt))
 
 ttt = time.time()
 a_list = np.empty((10**4, 10**4))
 a_list = list_rust.make_list_py(a_list)
 list_rust.iterate_list_multi_py(a_list)
-print("Rust with multithreading time: " + str(time.time() - ttt))
+print("Rust-numpy with multithreading time: " + str(time.time() - ttt))
+
+a_list = []  # type: ignore
+ttt = time.time()
+a_list = list_rust.make_list(a_list)
+list_rust.iterate_list(a_list)
+print("Rust multithreading before needed time: " + str(time.time() - ttt))
 
 a_list = []  # type: ignore
 ttt = time.time()
@@ -60,6 +66,13 @@ ttt = time.time()
 a_list = list_julia.make_list(a_list)
 list_julia.Threaded.iterate_list(a_list)
 print("Julia multi-threading needed time: " + str(time.time() - ttt))
+
+
+a_list = []  # type: ignore
+ttt = time.time()
+a_list = list_rust.make_list(a_list)
+list_rust.iterate_list(a_list)
+print("Rust multithreading after needed time: " + str(time.time() - ttt))
 
 a_list = []  # type: ignore
 ttt = time.time()

--- a/poetry.lock
+++ b/poetry.lock
@@ -57,6 +57,26 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "semantic-version"
+version = "2.8.5"
+description = "A library implementing the 'SemVer' scheme."
+category = "main"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+
+[[package]]
+name = "setuptools-rust"
+version = "0.12.1"
+description = "Setuptools Rust extension plugin"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+semantic-version = ">=2.6.0"
+toml = ">=0.9.0"
+
+[[package]]
 name = "toml"
 version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
@@ -67,7 +87,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 [metadata]
 lock-version = "1.1"
 python-versions = "3.9"
-content-hash = "109a253861bd440707d6c1790d701341ed40ed06425c14e3834d528cfdd696e0"
+content-hash = "53fae5951923b353a38007e20b2add6171230f48e1f1cee4fc37b4cc6679b4db"
 
 [metadata.files]
 cython = [
@@ -189,6 +209,14 @@ numpy = [
     {file = "numpy-1.20.2-cp39-cp39-win_amd64.whl", hash = "sha256:924dc3f83de20437de95a73516f36e09918e9c9c18d5eac520062c49191025fb"},
     {file = "numpy-1.20.2-pp37-pypy37_pp73-manylinux2010_x86_64.whl", hash = "sha256:97ce8b8ace7d3b9288d88177e66ee75480fb79b9cf745e91ecfe65d91a856042"},
     {file = "numpy-1.20.2.zip", hash = "sha256:878922bf5ad7550aa044aa9301d417e2d3ae50f0f577de92051d739ac6096cee"},
+]
+semantic-version = [
+    {file = "semantic_version-2.8.5-py2.py3-none-any.whl", hash = "sha256:45e4b32ee9d6d70ba5f440ec8cc5221074c7f4b0e8918bdab748cc37912440a9"},
+    {file = "semantic_version-2.8.5.tar.gz", hash = "sha256:d2cb2de0558762934679b9a104e82eca7af448c9f4974d1f3eeccff651df8a54"},
+]
+setuptools-rust = [
+    {file = "setuptools-rust-0.12.1.tar.gz", hash = "sha256:647009e924f0ae439c7f3e0141a184a69ad247ecb9044c511dabde232d3d570e"},
+    {file = "setuptools_rust-0.12.1-py3-none-any.whl", hash = "sha256:60c9bf1423a725e472c4a2a6274598251f959f3ed5ffe7698526e78bb431b9b7"},
 ]
 toml = [
     {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ maturin = "^0.10.3"
 julia = "^0.5.6"
 numpy = "^1.20.2"
 numba = "^0.53.1"
+setuptools-rust = "^0.12.1"
 
 [tool.poetry.dev-dependencies]
 

--- a/src/list_rust.rs
+++ b/src/list_rust.rs
@@ -1,32 +1,34 @@
+extern crate ndarray;
+use ndarray::parallel::prelude::*;
+use numpy::{PyArray2, PyReadonlyArray2};
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
-use rayon::prelude::*;
 
 #[pyfunction]
-fn iterate_list(py: Python, a_list: Vec<Vec<f64>>) -> f64 {
-    // let count = a_list.iter().map(|l| l.iter().sum::<f64>()).sum::<f64>();
-    let count = py.allow_threads(|| a_list.par_iter().map(|l| l.iter().sum::<f64>()).sum::<f64>());
-    println!("{}", count);
-        
-    return count;
+fn iterate_list_py<'py>(py: Python<'py>, a_list: PyReadonlyArray2<'_, f64>) -> f64 {
+    a_list.as_array().sum()
 }
 
 #[pyfunction]
-fn make_list(mut a_list: Vec<Vec<f64>>) -> Vec<Vec<f64>> {
-    for _i in 0..i64::pow(10, 4) {
-        let mut new_list = Vec::<f64>::new();
-        for _j in 0..i64::pow(10, 4) {
-            new_list.push(0.01_f64);
-        }
-        a_list.push(new_list);
+fn iterate_list_multi_py<'py>(py: Python<'py>, a_list: PyReadonlyArray2<'_, f64>) -> f64 {
+    a_list.as_array().into_par_iter().sum()
+}
+
+#[pyfunction]
+fn make_list_py<'py>(py: Python<'py>, a_list: &'py PyArray2<f64>) -> &'py PyArray2<f64> {
+    unsafe {
+        a_list.as_array_mut().fill(0.01);
     }
-    return a_list;
+    a_list
 }
 
 #[pymodule]
 fn list_rust(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_function(wrap_pyfunction!(iterate_list, m)?).unwrap();
-    m.add_function(wrap_pyfunction!(make_list, m)?).unwrap();
+    m.add_function(wrap_pyfunction!(iterate_list_py, m)?)
+        .unwrap();
+    m.add_function(wrap_pyfunction!(iterate_list_multi_py, m)?)
+        .unwrap();
+    m.add_function(wrap_pyfunction!(make_list_py, m)?).unwrap();
 
     Ok(())
 }

--- a/src/list_rust.rs
+++ b/src/list_rust.rs
@@ -22,6 +22,32 @@ fn make_list_py<'py>(py: Python<'py>, a_list: &'py PyArray2<f64>) -> &'py PyArra
     a_list
 }
 
+#[pyfunction]
+fn iterate_list(py: Python, a_list: Vec<Vec<f64>>) -> f64 {
+    // let count = a_list.iter().map(|l| l.iter().sum::<f64>()).sum::<f64>();
+    let count = py.allow_threads(|| {
+        a_list
+            .par_iter()
+            .map(|l| l.iter().sum::<f64>())
+            .sum::<f64>()
+    });
+    println!("{}", count);
+
+    return count;
+}
+
+#[pyfunction]
+fn make_list(mut a_list: Vec<Vec<f64>>) -> Vec<Vec<f64>> {
+    for _i in 0..i64::pow(10, 4) {
+        let mut new_list = Vec::<f64>::new();
+        for _j in 0..i64::pow(10, 4) {
+            new_list.push(0.01_f64);
+        }
+        a_list.push(new_list);
+    }
+    return a_list;
+}
+
 #[pymodule]
 fn list_rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(iterate_list_py, m)?)
@@ -29,6 +55,8 @@ fn list_rust(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(iterate_list_multi_py, m)?)
         .unwrap();
     m.add_function(wrap_pyfunction!(make_list_py, m)?).unwrap();
+    m.add_function(wrap_pyfunction!(iterate_list, m)?).unwrap();
+    m.add_function(wrap_pyfunction!(make_list, m)?).unwrap();
 
     Ok(())
 }

--- a/src/list_rust.rs
+++ b/src/list_rust.rs
@@ -10,27 +10,38 @@ fn iterate_list_py<'py>(py: Python<'py>, a_list: PyReadonlyArray2<'_, f64>) -> f
     //a_list.as_array().sum()
 
     // To comply with "Algorithm"
-    a_list
+    let sum = a_list
         .as_array()
         .axis_iter(Axis(0))
         .map(|row| row.sum())
-        .sum()
+        .sum();
+    println!("{}", sum);
+    sum
 }
 
 #[pyfunction]
 fn iterate_list_multi_py<'py>(py: Python<'py>, a_list: PyReadonlyArray2<'_, f64>) -> f64 {
-    a_list
+    let sum = a_list
         .as_array()
         .axis_iter(Axis(0))
         .into_par_iter()
         .map(|row| row.sum())
-        .sum()
+        .sum();
+    println!("{}", sum);
+    sum
 }
 
 #[pyfunction]
 fn make_list_py<'py>(py: Python<'py>, a_list: &'py PyArray2<f64>) -> &'py PyArray2<f64> {
     unsafe {
-        a_list.as_array_mut().fill(0.01);
+        // Idiomatic way
+        // a_list.as_array_mut().fill(0.01);
+
+        // Match the Algorithm description explicitly
+        a_list
+            .as_array_mut()
+            .axis_iter_mut(Axis(0))
+            .for_each(|mut row| row.fill(0.01))
     }
     a_list
 }

--- a/src/list_rust.rs
+++ b/src/list_rust.rs
@@ -1,17 +1,30 @@
 extern crate ndarray;
-use ndarray::parallel::prelude::*;
+use ndarray::{parallel::prelude::*, Axis};
 use numpy::{PyArray2, PyReadonlyArray2};
 use pyo3::prelude::*;
 use pyo3::wrap_pyfunction;
 
 #[pyfunction]
 fn iterate_list_py<'py>(py: Python<'py>, a_list: PyReadonlyArray2<'_, f64>) -> f64 {
-    a_list.as_array().sum()
+    // Idiomatic way
+    //a_list.as_array().sum()
+
+    // To comply with "Algorithm"
+    a_list
+        .as_array()
+        .axis_iter(Axis(0))
+        .map(|row| row.sum())
+        .sum()
 }
 
 #[pyfunction]
 fn iterate_list_multi_py<'py>(py: Python<'py>, a_list: PyReadonlyArray2<'_, f64>) -> f64 {
-    a_list.as_array().into_par_iter().sum()
+    a_list
+        .as_array()
+        .axis_iter(Axis(0))
+        .into_par_iter()
+        .map(|row| row.sum())
+        .sum()
 }
 
 #[pyfunction]
@@ -24,13 +37,13 @@ fn make_list_py<'py>(py: Python<'py>, a_list: &'py PyArray2<f64>) -> &'py PyArra
 
 #[pyfunction]
 fn iterate_list(py: Python, a_list: Vec<Vec<f64>>) -> f64 {
-    // let count = a_list.iter().map(|l| l.iter().sum::<f64>()).sum::<f64>();
-    let count = py.allow_threads(|| {
-        a_list
-            .par_iter()
-            .map(|l| l.iter().sum::<f64>())
-            .sum::<f64>()
-    });
+    let count = a_list.iter().map(|l| l.iter().sum::<f64>()).sum::<f64>();
+    // let count = py.allow_threads(|| {
+    //     a_list
+    //         .par_iter()
+    //         .map(|l| l.iter().sum::<f64>())
+    //         .sum::<f64>()
+    // });
     println!("{}", count);
 
     return count;


### PR DESCRIPTION
This adds a closer-to-real life version of the rust version. By passing a numpy array instead of a `PyList` we avoid 3 copies of the python list. Looking at the generate C code for some of the other versions, they don't have to copy the python list, they are just passing references around.

I couldn't get the julia stuff to work locally for me, so I haven't been able to compare this against the other methods. 

Last thing I'd add is that its probably not apples to apples since numpy requires the full allocation up front. Although I think it would improve the benchmark to have all the other implementations work off pre-allocated memory instead, since that's how this would be done IRL. 